### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -32,7 +32,7 @@ jobs:
         echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_APP_ID: ${{ secrets.GH_APP_ID }}
         GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
@@ -63,7 +63,7 @@ jobs:
         comment: 'Metrics report issue automatically closed after creation. Labels are retained.'
 
     - name: Report on PRs
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:snickerjp/docker-mysql-shell is:pr created:${{ env.last_month }} -is:draft'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チャー（保守）**
  * CI/CD ワークフロー構成を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->