### PR TITLE
fix: add Innovation tag, remove sha- tag from docker push

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -44,7 +44,7 @@ jobs:
             type=raw,value=${{ steps.version.outputs.full }}
             type=raw,value=${{ steps.version.outputs.minor }}
             type=raw,value=latest
-            type=sha,prefix=sha-
+            type=raw,value=Innovation
 
       - name: Build and push
         uses: docker/build-push-action@v7


### PR DESCRIPTION
This pull request makes a minor update to the Docker image tagging process in the GitHub Actions workflow. The change replaces the SHA-based tag with a new static tag.

- Docker image tagging:
  * [`.github/workflows/docker-push.yml`](diffhunk://#diff-5a710cc1366531dd79364c96fedb1060a064e1017145446c396b231705aa64cdL47-R47): Replaced the dynamic SHA-based Docker image tag with a static `Innovation` tag in the list of tags used during the build and push process.